### PR TITLE
DD_MAGIC reversed

### DIFF
--- a/zipstream/consts.py
+++ b/zipstream/consts.py
@@ -37,7 +37,7 @@ DD_STRUCT = struct.Struct(b"<LLL")
 DD_STRUCT64 = struct.Struct(b"<LQQ")
 DD_TUPLE = namedtuple("filecrc",
                       ("crc", "comp_size", "uncomp_size"))
-DD_MAGIC = b'\x08\x07\x4b\x50'
+DD_MAGIC = b'\x50\x4b\x07\x08'
 
 
 # central directory file header

--- a/zipstream/zipstream.py
+++ b/zipstream/zipstream.py
@@ -5,6 +5,7 @@
 #
 import os
 import time
+import urllib
 import zlib
 from . import consts
 
@@ -113,6 +114,9 @@ class ZipBase:
         if 'file' in data:
             file_struct['src'] = data['file']
             file_struct['stype'] = 'f'
+        elif 'url' in data:
+            file_struct['src'] = data['url']
+            file_struct['stype'] = 'u'
         elif 'stream' in data:
             file_struct['src'] = data['stream']
             file_struct['stype'] = 's'
@@ -268,6 +272,14 @@ class ZipStream(ZipBase):
             return
         if src_type == 'f':
             with open(src, "rb") as fh:
+                while True:
+                    part = fh.read(self.chunksize)
+                    if not part:
+                        break
+                    yield part
+            return
+        if src_type == 'u':
+            with urllib.request.urlopen(src) as fh:
                 while True:
                     part = fh.read(self.chunksize)
                     if not part:


### PR DESCRIPTION
The DD_MAGIC constant was incorrectly reversed causing zips to fail on Apple desktop unzip. 

Also, change to allow URL's as type for source of streaming (for example S3).