### PR TITLE
Allow Async Generators for Source of Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,23 @@ loop.run_until_complete(zip_async('example.zip', files))
 loop.stop()
 ```
 
+The List of files may also be an async generator:
+```python
+async def  files():
+    yield {
+              'file': '/tmp/car.jpeg'
+          },
+    yield {
+              'file': '/tmp/aaa.mp3', 
+              'name': 'music.mp3'
+          },
+    yield {
+        'stream': content_generator(),
+        'name': 'random_stuff.txt'
+           }
+ 
+```
+
 ## Examples
 
 See `examples` directory for complete code and working examples of ZipStream and AioZipStream.

--- a/examples/async_gen_files.py
+++ b/examples/async_gen_files.py
@@ -1,0 +1,62 @@
+import asyncio
+import random
+import io
+import zipstream
+import aiofiles
+async def generate_task(doc):
+    delay=random.randrange(0,5)
+    await asyncio.sleep(delay)
+    data= {"stream":   doc["data"],
+                "name":  doc["name"],
+                "compression": "deflate"}
+    print(f"finshed {data['name']} in {delay}s"  )
+    return data
+
+
+
+async def generated_content(size):
+    """
+    asynchronous source of random data of unknown length,
+    which we stream inside zip
+    """
+    chars = '0123456789 abcdefghijklmnopqrstuvwxyz \n'
+    for m in range(size):
+        t = ""
+        for n in range(random.randint(20, 200)):
+            t += random.choice(chars)
+        yield bytes(t, 'ascii')
+
+
+files = [
+    {'name': '/tmp/z/1.txt' ,"data": generated_content(50)},
+    {'name': '/tmp/z/2.txt',"data": generated_content(50)},
+    {'name': '/tmp/z/3.txt', "data":  generated_content(50)},
+    {'name': '/tmp/z/4.txt', "data":  generated_content(50)},
+    {'name': '/tmp/z/5.txt', "data":  generated_content(50)},
+
+]
+
+async def fileslistgen(docs):
+    """
+    This allows concurrency while files get streamed as completed
+    """
+    futures = []
+    for doc in docs:
+        futures.append((generate_task(doc)))
+
+    for coroutine in asyncio.as_completed(futures):
+        yield await coroutine
+
+
+async def zip_async(zipname, files):
+    # larger chunk size will increase performance
+    aiozip = zipstream.AioZipStream(
+    fileslistgen(files)
+)
+    async with aiofiles.open(zipname, mode='wb') as z:
+        async for chunk in aiozip.stream():
+            await z.write(chunk)
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(zip_async('example.zip', files))
+loop.stop()

--- a/examples/async_zip_stream.py
+++ b/examples/async_zip_stream.py
@@ -37,3 +37,4 @@ files = [
 loop = asyncio.get_event_loop()
 loop.run_until_complete(zip_async('example.zip', files))
 loop.stop()
+

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='zipstream',
-    version='0.5',
+    version='0.5.1',
 
     description='Creating zip files on the fly',
     long_description=long_description,

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,9 +1,11 @@
-import pytest
+import io
 
+import pytest
+import zlib
 pytestmark = pytest.mark.asyncio
 import zipstream
 from tests.test_zipstream import ZipStreamTestCase
-
+import zipfile
 
 async def asyncfileslist():
     with open("/tmp/_tempik_1.txt", "w") as f:
@@ -22,7 +24,7 @@ def  syncfileslist():
     yield {"file": "/tmp/_tempik_1.txt"}
     yield {"file": "/tmp/_tempik_2.txt"}
 
-
+FILENAMES=set(fd["file"].split("/")[-1] for fd in syncfileslist())
 
 async def test_async_generator_for_files():
     gen=asyncfileslist()
@@ -42,3 +44,9 @@ async def zipgen(gen):
 
     async for f in zs.stream():
         res += f
+    zf=zipfile.ZipFile(io.BytesIO(res))
+    filenames=set(zipinfo.filename for zipinfo  in zf.filelist)
+    assert not  filenames.difference(FILENAMES)
+
+
+

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,44 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+import zipstream
+from tests.test_zipstream import ZipStreamTestCase
+
+
+async def asyncfileslist():
+    with open("/tmp/_tempik_1.txt", "w") as f:
+        f.write("foo baz bar")
+    with open("/tmp/_tempik_2.txt", "w") as f:
+        f.write("baz trololo something")
+    yield {"file": "/tmp/_tempik_1.txt"}
+    yield {"file": "/tmp/_tempik_2.txt"}
+
+
+def  syncfileslist():
+    with open("/tmp/_tempik_1.txt", "w") as f:
+        f.write("foo baz bar")
+    with open("/tmp/_tempik_2.txt", "w") as f:
+        f.write("baz trololo something")
+    yield {"file": "/tmp/_tempik_1.txt"}
+    yield {"file": "/tmp/_tempik_2.txt"}
+
+
+
+async def test_async_generator_for_files():
+    gen=asyncfileslist()
+    await zipgen(gen)
+
+async  def   test_sync_generator_for_files():
+    gen=syncfileslist()
+    await zipgen(gen)
+
+async  def   test_sync_list_for_files():
+    gen=list(syncfileslist())
+    await zipgen(gen)
+
+async def zipgen(gen):
+    zs = zipstream.AioZipStream(gen)
+    res = b""
+
+    async for f in zs.stream():
+        res += f

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,11 +1,9 @@
 import io
-
 import pytest
-import zlib
-pytestmark = pytest.mark.asyncio
 import zipstream
-from tests.test_zipstream import ZipStreamTestCase
 import zipfile
+import aiofiles
+pytestmark = pytest.mark.asyncio
 
 async def asyncfileslist():
     with open("/tmp/_tempik_1.txt", "w") as f:
@@ -24,21 +22,59 @@ def  syncfileslist():
     yield {"file": "/tmp/_tempik_1.txt"}
     yield {"file": "/tmp/_tempik_2.txt"}
 
-FILENAMES=set(fd["file"].split("/")[-1] for fd in syncfileslist())
+async def asyncfileslist_streams():
+    with open("/tmp/_tempik_1.txt", "w") as f:
+        f.write("foo baz bar")
+    with open("/tmp/_tempik_2.txt", "w") as f:
+        f.write("baz trololo something")
+    async with aiofiles.open("/tmp/_tempik_1.txt","rb") as f:
+        yield {"stream":f ,
+                         "name": "_tempik_1.txt"
+               }
+    async with aiofiles.open("/tmp/_tempik_2.txt","rb") as f:
+        yield {"stream": f,
+               "name": "_tempik_2.txt"
+               }
+
+
+async def asyncfileslist_stream_iter ():
+    with open("/tmp/_tempik_1.txt", "w") as f:
+        f.write("foo baz bar")
+    with open("/tmp/_tempik_2.txt", "w") as f:
+        f.write("baz trololo something")
+    with open("/tmp/_tempik_1.txt","rb") as f:
+        yield {"stream":f ,
+                         "name": "_tempik_1.txt"
+               }
+    with open("/tmp/_tempik_2.txt","rb") as f:
+        yield {"stream": f,
+               "name": "_tempik_2.txt"
+               }
+
 
 async def test_async_generator_for_files():
     gen=asyncfileslist()
-    await zipgen(gen)
+    await zip_gen_and_check(gen)
 
 async  def   test_sync_generator_for_files():
     gen=syncfileslist()
-    await zipgen(gen)
+    await zip_gen_and_check(gen)
 
 async  def   test_sync_list_for_files():
     gen=list(syncfileslist())
-    await zipgen(gen)
+    await zip_gen_and_check(gen)
 
-async def zipgen(gen):
+async  def  test_async_list_for_async_get():
+    gen=asyncfileslist_streams()
+    await zip_gen_and_check(gen)
+
+async  def  test_async_list_for_iter():
+    gen=asyncfileslist_stream_iter()
+    await zip_gen_and_check(gen)
+
+
+async def zip_gen_and_check(gen):
+    FILENAMES = set(fd["file"].split("/")[-1] for fd in syncfileslist())
     zs = zipstream.AioZipStream(gen)
     res = b""
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -3,7 +3,9 @@ import pytest
 import zipstream
 import zipfile
 import aiofiles
+
 pytestmark = pytest.mark.asyncio
+
 
 async def asyncfileslist():
     with open("/tmp/_tempik_1.txt", "w") as f:
@@ -14,7 +16,7 @@ async def asyncfileslist():
     yield {"file": "/tmp/_tempik_2.txt"}
 
 
-def  syncfileslist():
+def syncfileslist():
     with open("/tmp/_tempik_1.txt", "w") as f:
         f.write("foo baz bar")
     with open("/tmp/_tempik_2.txt", "w") as f:
@@ -22,54 +24,61 @@ def  syncfileslist():
     yield {"file": "/tmp/_tempik_1.txt"}
     yield {"file": "/tmp/_tempik_2.txt"}
 
+
 async def asyncfileslist_streams():
     with open("/tmp/_tempik_1.txt", "w") as f:
         f.write("foo baz bar")
     with open("/tmp/_tempik_2.txt", "w") as f:
         f.write("baz trololo something")
-    async with aiofiles.open("/tmp/_tempik_1.txt","rb") as f:
-        yield {"stream":f ,
-                         "name": "_tempik_1.txt"
-               }
-    async with aiofiles.open("/tmp/_tempik_2.txt","rb") as f:
-        yield {"stream": f,
-               "name": "_tempik_2.txt"
-               }
+    async with aiofiles.open("/tmp/_tempik_1.txt", "rb") as f:
+        yield {
+            "stream": f,
+            "name": "_tempik_1.txt"
+        }
+    async with aiofiles.open("/tmp/_tempik_2.txt", "rb") as f:
+        yield {
+            "stream": f,
+            "name": "_tempik_2.txt"
+        }
 
 
-async def asyncfileslist_stream_iter ():
+async def asyncfileslist_stream_iter():
     with open("/tmp/_tempik_1.txt", "w") as f:
         f.write("foo baz bar")
     with open("/tmp/_tempik_2.txt", "w") as f:
         f.write("baz trololo something")
-    with open("/tmp/_tempik_1.txt","rb") as f:
-        yield {"stream":f ,
-                         "name": "_tempik_1.txt"
+    with open("/tmp/_tempik_1.txt", "rb") as f:
+        yield {"stream": f,
+               "name": "_tempik_1.txt"
                }
-    with open("/tmp/_tempik_2.txt","rb") as f:
+    with open("/tmp/_tempik_2.txt", "rb") as f:
         yield {"stream": f,
                "name": "_tempik_2.txt"
                }
 
 
 async def test_async_generator_for_files():
-    gen=asyncfileslist()
+    gen = asyncfileslist()
     await zip_gen_and_check(gen)
 
-async  def   test_sync_generator_for_files():
-    gen=syncfileslist()
+
+async def test_sync_generator_for_files():
+    gen = syncfileslist()
     await zip_gen_and_check(gen)
 
-async  def   test_sync_list_for_files():
-    gen=list(syncfileslist())
+
+async def test_sync_list_for_files():
+    gen = list(syncfileslist())
     await zip_gen_and_check(gen)
 
-async  def  test_async_list_for_async_get():
-    gen=asyncfileslist_streams()
+
+async def test_async_list_for_async_get():
+    gen = asyncfileslist_streams()
     await zip_gen_and_check(gen)
 
-async  def  test_async_list_for_iter():
-    gen=asyncfileslist_stream_iter()
+
+async def test_async_list_for_iter():
+    gen = asyncfileslist_stream_iter()
     await zip_gen_and_check(gen)
 
 
@@ -80,9 +89,6 @@ async def zip_gen_and_check(gen):
 
     async for f in zs.stream():
         res += f
-    zf=zipfile.ZipFile(io.BytesIO(res))
-    filenames=set(zipinfo.filename for zipinfo  in zf.filelist)
-    assert not  filenames.difference(FILENAMES)
-
-
-
+    zf = zipfile.ZipFile(io.BytesIO(res))
+    filenames = set(zipinfo.filename for zipinfo in zf.filelist)
+    assert not filenames.difference(FILENAMES)

--- a/zipstream/aiozipstream.py
+++ b/zipstream/aiozipstream.py
@@ -47,9 +47,14 @@ class AioZipStream(ZipBase):
 
     async def data_generator(self, src, src_type):
         if src_type == 's':
-            async for chunk in src:
-                yield chunk
-            return
+            if hasattr(src,"__anext__",):
+                async for chunk in src:
+                    yield chunk
+                return
+            else:
+                for chunk in src:
+                    yield chunk
+                return
         if src_type == 'f':
             async with aiofiles.open(src, "rb") as fh:
                 while True:


### PR DESCRIPTION
This adds tests for the async features of zipstream and also extends the AioZipStream class to accept async generators as files source.  It also accepts normal file like objects as stream now. This opens up the ability to start streaming, while data is loaded concurrently see

 `/examples/async_gen_files.py`.
 
addresses #3 